### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-The original soaplib project was renamed to [http://github.com/arskom/spyne](spyne).
+The original soaplib project was renamed to [spyne](http://github.com/arskom/spyne).
 
-It was also forked as [http://github.com/soaplib/soaplib](soaplib).
+It was also forked as [soaplib](http://github.com/soaplib/soaplib).


### PR DESCRIPTION
The name/URL parts of the markdown were swapped around.  Now the links actually go to the right places.